### PR TITLE
[require-uuid] change from import -to-> require

### DIFF
--- a/src/handler.js
+++ b/src/handler.js
@@ -2,7 +2,7 @@ const _ = require('lodash');
 const { HttpStatusError } = require('./errors');
 const { parse } = require('./parser');
 const { distinct, raw } = require('./transforms');
-import uuidv1 from 'uuid/v1';
+const uuidv1 = require('uuid/v1');
 
 class ModelHandler {
   constructor(model, defaults = { limit: 50, offset: 0 }) {


### PR DESCRIPTION
* Uses `require()` instead of `import()`
  * Matches rest of file
  * Consuming apps typically ignore `node_modules` when running Babel, and this package is not being transpiled, thus `import` will most likely not work.

This breaks installation from this fork in npm, so it needs resolved :-)
